### PR TITLE
Print the time when a stage promotion occurred

### DIFF
--- a/vars/promotionHelper.groovy
+++ b/vars/promotionHelper.groovy
@@ -51,3 +51,13 @@ static int getUpstreamTriggerOrLatestBuildNumber(RunWrapper promotedBuild, Strin
     println(">> Manual trigger detected, using latest build ${build.getFullDisplayName()}")
     return buildNum
 }
+
+/**
+ * Print the time when a stage promotion occurred
+ *
+ * @param stage the stage being promoted to
+ */
+void printStagePromotionTime(String stage) {
+    def date = java.time.LocalDateTime.now()
+    println("Promoted to ${stage} at ${date}")
+}


### PR DESCRIPTION
Code moved from https://github.com/aodn/cloud-deploy/pull/767

This way if we ever change it, we only have to change it in one place.

Re. talked about desire to print out who approved the promotion: turns out that's already being printed:
![image](https://user-images.githubusercontent.com/1926880/80558306-3f5d8680-8a1d-11ea-94b2-736e68dac7a9.png)


Part of https://github.com/aodn/backlog/issues/1688