### PR TITLE
Allow any arbitrary chef branch to be set via environment

### DIFF
--- a/test/unit/groovy/ChefHelperTest.groovy
+++ b/test/unit/groovy/ChefHelperTest.groovy
@@ -150,7 +150,7 @@ class ChefHelperTest extends BasePipelineTest {
 
     @Test
     void getTagForEnvironment_ReturnsDefault_WithUnknownEnvironments() throws Exception {
-        assertEquals("prod", chefHelper.getTagForEnvironment("unknown"))
+        assertEquals("unknown", chefHelper.getTagForEnvironment("unknown"))
     }
     @Test
     void getTagForNode_ReturnsProdTag_WithKnownEnvironment() throws Exception {

--- a/vars/chefHelper.groovy
+++ b/vars/chefHelper.groovy
@@ -83,7 +83,7 @@ static List<String> getNodesForEnvironment(String environment, String nodesDirec
 }
 
 /**
- * Get a Git tag corresponding to a given chef environment. If the enviroment is unknown, default to returning 'prod'
+ * Get a Git tag corresponding to a given chef environment. If the enviroment is unknown, default to returning the environment name itself.
  *
  * @param environment chef_environment value for which to find the matching tag
  * @return tag name for the given environment name
@@ -94,7 +94,7 @@ static String getTagForEnvironment(String environment) throws RuntimeException {
             'testing': 'systest',
             'production': 'prod'
     ]
-    String tag = environmentToTagMap.get(environment, 'prod')
+    String tag = environmentToTagMap.get(environment, environment)
     return tag
 }
 


### PR DESCRIPTION
For https://github.com/aodn/backlog/issues/3061

Will allow us to set up nodes that cook from the WSD specific chef branch

None of the nodes are using the 'prod' default setting right now, nor have they ever. When we want a node to be a production node we naturally set the chef_environment directly to "production".